### PR TITLE
Add necessary Semigroup instance for forward compatability

### DIFF
--- a/Data/Distribution/Aggregator.hs
+++ b/Data/Distribution/Aggregator.hs
@@ -48,11 +48,14 @@ newtype Aggregator a = Aggregator
       --   of probabilities.
     }
 
--- | 'mempty' is the aggregator that leaves probabilities untouched,
---   and 'mappend' compose aggregators.
+-- | Compose aggregators with `(<>)`
+instance Semigroup (Aggregator a) where
+    (Aggregator f) <> g = Aggregator (f . aggregateWith g)
+
+-- | 'mempty' is the aggregator that leaves probabilities untouched
 instance Monoid (Aggregator a) where
     mempty = Aggregator (map snd)
-    mappend (Aggregator f) g = Aggregator (f . aggregateWith g)
+    mappend = (<>)
 
 -- | Applies an aggregator on a list of values tagged with their probability.
 --   The values themselves are left unchanged.

--- a/Data/Distribution/Core.hs
+++ b/Data/Distribution/Core.hs
@@ -170,9 +170,12 @@ instance (Ord a, Floating a) => Floating (Distribution a) where
     atanh = select atanh
     acosh = select acosh
 
+instance (Ord a, Semigroup a) => Semigroup (Distribution a) where
+    d1 <> d2 = combineWith (<>) d1 d2
+
 instance (Ord a, Monoid a) => Monoid (Distribution a) where
     mempty = always mempty
-    mappend d1 d2 = combineWith mappend d1 d2
+    mappend = (<>)
 
 -- | Converts the distribution to a list of increasing values whose probability
 --   is greater than @0@. To each value is associated its probability.


### PR DESCRIPTION
This patch does not address keeping the code compatible with older versions
of GHC.

Because the `distribution` package is relatively self-contained, my
recommendation would be to just use an older version of the package
when you want to use an old GHC.