### PR TITLE
Bump containers and random version constraints

### DIFF
--- a/distribution.cabal
+++ b/distribution.cabal
@@ -61,7 +61,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       array >=0.4,
                        base >=4.5 && <5,
-                       containers ==0.5.*,
+                       containers ==0.6.*,
                        MonadRandom >=0.4,
-                       random ==1.1.*
+                       random ==1.2.*
 


### PR DESCRIPTION
As mentioned in https://github.com/jmct/haskell-distribution/pull/1

> Allows use on the latest stackage LTS snapshot

Thank you @ThomasRules2000 for doing this minor tweak.